### PR TITLE
Fix issues found by shellcheck

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-project_dir=$1
+project_dir="$1"
 
-mkdir $project_dir
-cd $project_dir
+mkdir "$project_dir"
+cd "$project_dir"
 
 echo "initializing '$project_dir'"
 git init > /dev/null
 
-PORT='$PORT'
+PORT="$PORT"
 
 cat > package.json << EOL
 {
@@ -40,7 +40,7 @@ echo "installing dependencies"
 npm install --save-dev elm-tooling elm-live > /dev/null
 npm install --save http-server > /dev/null
 
-export PATH=$PATH:node_modules/.bin
+export PATH="$PATH":node_modules/.bin
 
 yes | elm-tooling init > /dev/null
 elm-tooling install > /dev/null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-elm-live-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Set up a modern elm app by running one command.",
   "bin": {
     "create-elm-live-app": "index.sh"


### PR DESCRIPTION
When you have to write shell scripts, [use a linter](https://www.shellcheck.net/).

 - Variables should be quoted to prevent word splitting.
 - When variable expansion is desired, use double quotes, not single quotes.

I'm not sure about quoting in the `project_dir="$1"` assignment, but when it comes to POSIX shell and quoting, it's better to be safe now than to chase obscure bugs later.